### PR TITLE
Add team edit panel (ref: #87)

### DIFF
--- a/web/web/blueprints/admin/__init__.py
+++ b/web/web/blueprints/admin/__init__.py
@@ -59,6 +59,15 @@ def update_user():
     flash(f'User {user.email} updated successfully', category="success")
     return redirect(request.referrer)
 
+@admin.route('/update_team', methods=['POST'])
+@roles_required('admin')
+def update_team():
+    team = Team.query.get(int(request.form['teamid']))
+    team.name = request.form['name']
+    db.session.commit()
+    flash(f'Team {team.name} updated', category="success")
+    return redirect(request.referrer)
+
 @admin.route('/teams')
 @roles_required('admin')
 def teams():

--- a/web/web/blueprints/admin/templates/admin/teams.html
+++ b/web/web/blueprints/admin/templates/admin/teams.html
@@ -34,6 +34,37 @@
         </div>
     </div>
 </div>
+
+
+<div class="modal fade" id="editTeamModal" tabindex="-1" role="dialog" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered" role="document">
+        <div class="modal-content">
+            <form action="{{ url_for('admin.update_team') }}" method="POST">
+            <input type="hidden" name="teamid" id="changeTeamTeamID">
+            <div class="modal-header">
+                <h5 class="modal-title">Edit <span class="teamToEdit"></span></h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body">
+                <div class="form-group">
+                    <label for="changeTeamNameInput">Name</label>
+                    <input type="text" class="form-control" name="name" id="changeTeamNameInput">
+                </div>
+                <label for="team-member-list">Members</label>
+                <ul class="list-group" id="team-member-list">
+                </ul>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+                <button type="submit" class="btn btn-primary">Save changes</button>
+            </div>
+            </form>
+        </div>
+    </div>
+</div>
+
 <table class="table table-hover">
     <thead>
         <tr>
@@ -52,9 +83,13 @@
                 {% endfor %}
             </td>
             <td>
-                <form method="POST" id="delete_team_{{ team.id }}" action="{{ url_for('admin.delete_team', team_id=team.id) }}">
-                    <a href="#" onclick="if (confirm('Are you sure you want to delete {{ team.name }}?')) document.getElementById('delete_team_{{ team.id }}').submit()">Delete</button>
-                </form>
+                <a href="#"
+                    data-teamid="{{ team.id }}"
+                    data-name="{{ team.name }}"
+                    data-members='{{ team.member_names | tojson }}'
+                    class="edit-team-link">Edit</a> |
+                <form style="display:none;" method="POST" id="delete_team_{{ team.id }}" action="{{ url_for('admin.delete_team', team_id=team.id) }}"></form>
+                <a href="#" onclick="if (confirm('Are you sure you want to delete {{ team.name }}?')) document.getElementById('delete_team_{{ team.id }}').submit()">Delete</button>
             </td>
         </tr>
         {% endfor %}
@@ -65,6 +100,52 @@
 
 {% block scripts %}
 <script>
+document.querySelectorAll('.edit-team-link').forEach(function(el) {
+    el.onclick = function() {
+        // Get current team data from clicked link
+        let teamid = el.dataset.teamid;
+        let name = el.dataset.name;
+        let members = JSON.parse(el.dataset.members);
+
+        // Update form header
+        document.querySelectorAll('.teamToEdit').forEach(el => el.innerHTML = name);
+
+        // Update edit form body
+        document.getElementById('changeTeamTeamID').value = teamid;
+        document.getElementById('changeTeamNameInput').value = name;
+
+        // Update team member list (note that this doesn't (yet?) support editing)
+        let teamMemberList = document.getElementById("team-member-list");
+        teamMemberList.innerHTML=""; // Clear out any old nodes
+        if (members.length > 0) {
+            for (let member of members) {
+                let memberItem = document.createElement("li");
+                memberItem.innerHTML = member;
+                memberItem.classList.add("list-group-item", "py-1");
+                teamMemberList.append(memberItem);
+            }
+        } else {
+            let memberItem = document.createElement("li");
+            memberItem.innerHTML = "<em>No members on this team</em>";
+            memberItem.classList.add("list-group-item", "py-1");
+            teamMemberList.prepend(memberItem);
+        }
+        // A potential edit button, once the backend supports it:
+        //let addMemberButton = document.createElement("button");
+        //addMemberButton.innerHTML = "Add Members";
+        //addMemberButton.classList.add("list-group-item", "py-1", "active");
+        //addMemberButton.setAttribute("type", "button");
+        //addMemberButton.addEventListener("click", function() { ... } );
+        //teamMemberList.append(addMemberButton);
+
+        // Show modal
+        $('#editTeamModal').modal();
+
+        // Don't do anything with the link click
+        return false;
+    };
+});
+
 $('.modal').on('shown.bs.modal', function() {
     $(this).find('input:first').focus();
 });

--- a/web/web/models/team.py
+++ b/web/web/models/team.py
@@ -41,6 +41,10 @@ class Team(db.Model):
             config.write("[receive]\n\tdenyCurrentBranch = ignore\n")
 
     @property
+    def member_names(self):
+        return [member.name for member in self.members]
+
+    @property
     def results(self):
         return db.session.query(Result).from_statement(
             text("""WITH results AS (


### PR DESCRIPTION
This PR adds an "edit" link to teams (potentially closing #87):
![2020-04-28-201411_810x516_scrot](https://user-images.githubusercontent.com/8261698/80552729-24433600-898d-11ea-8630-11ee935718ab.png)

which pops up this modal:
![2020-04-28-201519_3840x1080_scrot](https://user-images.githubusercontent.com/8261698/80552728-23aa9f80-898d-11ea-9908-c5b52f55352d.png)

(Due to some potentially confusing and/or buggy UI, I didn't implement a way to edit team members from this screen. Users should be added to teams on the Users page.)