### PR TITLE
Add git endpoint for Admins to download all teams' code

### DIFF
--- a/web/web/blueprints/admin/templates/admin/teams.html
+++ b/web/web/blueprints/admin/templates/admin/teams.html
@@ -39,6 +39,7 @@
         <tr>
             <th>Name</th>
             <th>Members</th>
+            <th>Admin Git Clone URL</th>
             <th>Actions</th>
         </tr>
     </thead>
@@ -50,6 +51,9 @@
                 {% for user in team.members %}
                 {{ user.email }}<br>
                 {% endfor %}
+            </td>
+            <td>
+                <a href="{{ url_for('program.index_team', team_id=team.id) }}">{{ url_for('program.index_team', team_id=team.id) }}</a>
             </td>
             <td>
                 <form method="POST" id="delete_team_{{ team.id }}" action="{{ url_for('admin.delete_team', team_id=team.id) }}">

--- a/web/web/blueprints/program/templates/program/submit.html
+++ b/web/web/blueprints/program/templates/program/submit.html
@@ -16,7 +16,7 @@ at Git commit <code>{{ commit.id.decode()[:7] }}</code>.</p>
 <!-- Server admin: if this shows localhost:5000, make sure you're passing
 the Host header (not the X-Forwarded-Host, as Werkzeug since v0.15 seems
 to not pick this up correctly) through to the application. -->
-<code>git clone {{ request.url_root }}program &lt;destination&gt;</code></p>
+<code>git clone {{ git_url }} &lt;destination&gt;</code></p>
 
 <h3>Submitting/Uploading your Program</h3>
 <p>To submit your program, simply run <code>git push</code> from within your


### PR DESCRIPTION
![2020-04-28-211059_893x515_scrot](https://user-images.githubusercontent.com/8261698/80555077-c87cab00-8994-11ea-93f8-c8ed86b598ef.png)

An admin user can `git clone https://hack.d.umn.edu/program/{teamid}` for push and pull access to a team's repo. (fixes #83)