### PR TITLE
Add a jump-to-result feature when coming from attack pages to team pages

### DIFF
--- a/web/web/blueprints/attacks/templates/attacks/show.html
+++ b/web/web/blueprints/attacks/templates/attacks/show.html
@@ -46,7 +46,7 @@
 <h4>Teams passing:</h4>
 <ul>
 {% for result in attack.passing %}
-<li><a href="{{ url_for('teams.show', team_id=result.team.id) }}">{{ result.team.name }}</a></li>
+<li><a href="{{ url_for('teams.show', team_id=result.team.id) }}#row{{ result.id }}">{{ result.team.name }}</a></li>
 {% else %}
 <span style="color:gray;">No teams are currently passing.</span>
 {% endfor %}
@@ -56,7 +56,7 @@
 <h4>Teams failing:</h4>
 <ul>
 {% for result in attack.failing %}
-<li><a href="{{ url_for('teams.show', team_id=result.team.id) }}">{{ result.team.name }}</a></li>
+<li><a href="{{ url_for('teams.show', team_id=result.team.id) }}#row{{ result.id }}">{{ result.team.name }}</a></li>
 {% else %}
 <span style="color:gray;">No teams are currently failing.</span>
 {% endfor %}

--- a/web/web/blueprints/teams/__init__.py
+++ b/web/web/blueprints/teams/__init__.py
@@ -25,6 +25,9 @@ def get_results_for_show_page(team_id: int) -> List[Result]:
 
 @teams.route('/<int:team_id>')
 def show(team_id):
+    """Show the passing/failing attacks of team `team_id`. Optionally can be
+       passed a hash in the URI such as `#row123` to highlight result #123
+       (useful for example when coming from an attack page)."""
     team=Team.query.get_or_404(team_id)
     return render_template('teams/show.html', team=team, results=get_results_for_show_page(team_id))
 

--- a/web/web/blueprints/teams/templates/teams/show.html
+++ b/web/web/blueprints/teams/templates/teams/show.html
@@ -50,3 +50,12 @@
   </table>
 
 {% endblock %}
+{% block scripts %}
+<script>
+$(function() {
+  if(location.hash != null && location.hash != ""){
+      $(location.hash + '.collapse').collapse('show');
+  }
+});
+</script>
+{% endblock %}


### PR DESCRIPTION
On an attack page:
![2020-04-28-225528_888x687_scrot](https://user-images.githubusercontent.com/8261698/80559670-f6b5b700-89a3-11ea-974b-4c1364d9d44d.png)

Clicking on a team previously simply led to the results list:
![2020-04-28-225546_888x608_scrot](https://user-images.githubusercontent.com/8261698/80559686-07fec380-89a4-11ea-91af-9b995e9090c0.png)

Now it directly opens the selected attack:
![2020-04-28-225537_890x630_scrot](https://user-images.githubusercontent.com/8261698/80559695-0fbe6800-89a4-11ea-80a8-15e6c1765a90.png)
