### PR TITLE
Allow unauthenticated postgres connections

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,6 @@ services:
         networks:
             - backend
         environment:
-            - REDIS_HOST=store
-            - POSTGRES_HOST=db
             - POSTGRES_HOST_AUTH_METHOD=trust
     worker:
         build: worker
@@ -45,7 +43,6 @@ services:
         environment:
             - REDIS_HOST=store
             - POSTGRES_HOST=db
-            - POSTGRES_HOST_AUTH_METHOD=trust
 networks:
     backend:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,10 @@ services:
             - db_data:/var/lib/postgresql/data
         networks:
             - backend
+        environment:
+            - REDIS_HOST=store
+            - POSTGRES_HOST=db
+            - POSTGRES_HOST_AUTH_METHOD=trust
     worker:
         build: worker
         networks:
@@ -41,6 +45,7 @@ services:
         environment:
             - REDIS_HOST=store
             - POSTGRES_HOST=db
+            - POSTGRES_HOST_AUTH_METHOD=trust
 networks:
     backend:
 


### PR DESCRIPTION
This was necessary to get the database docker container running after an update to postgres. We might want to consider changing this in the future, as unauthenticated database connections are usually not advised. We are currently running DTANM on its own network, so there should be no concern right now. A possible alternative is to require a password for postgres.