### PR TITLE
Add Attack and Team 404 Handlers

### DIFF
--- a/web/web/blueprints/attacks/__init__.py
+++ b/web/web/blueprints/attacks/__init__.py
@@ -2,6 +2,7 @@ from flask import render_template, Blueprint, flash, request, url_for, redirect,
 from flask_security import login_required, current_user
 from web.models.attack import Attack, create_attack_from_post, create_attack_from_tar
 from werkzeug.utils import secure_filename
+from werkzeug.exceptions import NotFound
 from web.models.task import add_task
 from web import db, team_required
 import os
@@ -84,3 +85,12 @@ def download(attack_id):
 @team_required
 def create():
     return render_template('attacks/create.html')
+
+@attacks.errorhandler(NotFound)
+def handle_not_found_error(e):
+    if (request.referrer is None):
+        response = render_template('error/item_not_found.html', object='attack', object_plural='attacks', list_page_id='attacks.index', list_page_name='Attacks')
+        return response
+    else:
+        flash('Requested attack does not exist.', category="error")
+        return redirect(request.referrer)

--- a/web/web/blueprints/teams/__init__.py
+++ b/web/web/blueprints/teams/__init__.py
@@ -6,6 +6,7 @@ from web.models.result import Result
 from sqlalchemy.sql import text
 from typing import List
 from web.blueprints.teams.formatters import TextFormatter, HexFormatter
+from werkzeug.exceptions import NotFound
 
 teams = Blueprint('teams', __name__, template_folder='templates')
 
@@ -49,3 +50,12 @@ def show_table(team_id):
 @team_required
 def me():
     return show(current_user.team_id)
+
+@teams.errorhandler(NotFound)
+def handle_not_found_error(e):
+    if (request.referrer is None):
+        response = render_template('error/item_not_found.html', object='team', object_plural='teams', list_page_id='teams.index', list_page_name='Team Rankings')
+        return response
+    else:
+        flash('Requested team does not exist.', category="error")
+        return redirect(request.referrer)

--- a/web/web/templates/error/item_not_found.html
+++ b/web/web/templates/error/item_not_found.html
@@ -1,0 +1,8 @@
+{% extends "layouts/base.html" %}
+
+{% block title %}Error: Requested {{ object.capitalize() }} Not Found {% endblock %}
+
+{% block content %}
+<p>There was an error locating the {{ object }} you requested. Visit <a href="{{ url_for(list_page_id) }}">{{ list_page_name }}</a> to view the list of available {{ object_plural }}.</p>
+
+{% endblock %}


### PR DESCRIPTION
Ref Issue #119 

This PR adds HTTP 404 - Not Found error handlers to the Teams and Attacks blueprints. If a user has directly navigated to an attack or team that does not exist, the 'object_not_found.html' template is displayed:

![image](https://user-images.githubusercontent.com/8886072/138619045-6107f663-4a33-4dc2-a169-8d66ee811de5.png)
![image](https://user-images.githubusercontent.com/8886072/138619059-3874110f-1763-4703-bdfa-b1a7451b9327.png)

If a request for an invalid attack or team does have a referrer set, the error handler will redirect back to the referring page and display an error toast popup:

![image](https://user-images.githubusercontent.com/8886072/138619184-c7e9b52c-b425-4636-9809-66e8f711715b.png)

I chose to implement both behaviors because it seemed frustrating to make users that clicked a broken link in the UI navigate back to where they came from, but users that clicked a link from outside the site that led to a non-existent page would not see a toast error. It would be trivial to adopt one approach over the other, or to introduce other types of error handlers.