### PR TITLE
Keep state of "Automatically refresh results" checkboxes, fixes #146

### DIFF
--- a/web/web/blueprints/teams/templates/teams/index.html
+++ b/web/web/blueprints/teams/templates/teams/index.html
@@ -6,7 +6,7 @@
 <form class="form-inline">
   <button type="button" class="btn btn-primary mb-2 me-sm-2" onclick="reloadTable()">Reload results</button>
   <div class="form-check mb-2 me-sm-2">
-    <input class="form-check-input" type="checkbox" id="autorefresh-checkbox">
+    <input class="form-check-input" type="checkbox" id="autorefresh-checkbox"  onclick="autoRefreshClick(this);">
     <label class="form-check-label" for="autorefresh-checkbox">
       Automatically refresh results
     </label>
@@ -31,5 +31,15 @@ $(function() {
     }
   }, 10000);
 });
+
+document.addEventListener('DOMContentLoaded', (event) => {
+  if (localStorage["autorefresh"] === 'true') {
+    document.getElementById('autorefresh-checkbox').checked = true
+  }
+});
+
+function autoRefreshClick(cb) {
+  localStorage["autorefresh"] = cb.checked
+}
 </script>
 {% endblock %}

--- a/web/web/blueprints/teams/templates/teams/show.html
+++ b/web/web/blueprints/teams/templates/teams/show.html
@@ -13,7 +13,7 @@
 <form class="form-inline">
   <button type="button" class="btn btn-primary mb-2 me-sm-2" onclick="reloadTable()">Reload results</button>
   <div class="form-check mb-2 me-sm-2">
-    <input class="form-check-input" type="checkbox" id="autorefresh-checkbox">
+    <input class="form-check-input" type="checkbox" id="autorefresh-checkbox" onclick="autoRefreshClick(this);">
     <label class="form-check-label" for="autorefresh-checkbox">
       Automatically refresh results
     </label>
@@ -44,5 +44,15 @@ $(function() {
     }
   }, 10000);
 });
+
+document.addEventListener('DOMContentLoaded', (event) => {
+  if (localStorage["autorefresh"] === 'true') {
+    document.getElementById('autorefresh-checkbox').checked = true
+  }
+});
+
+function autoRefreshClick(cb) {
+  localStorage["autorefresh"] = cb.checked
+}
 </script>
 {% endblock %}


### PR DESCRIPTION
Implemented using option #2, the browser's local storage and linked the state of both auto refresh boxes.